### PR TITLE
fix: correct generated key mappings in response files

### DIFF
--- a/src/api/transformdApiSearchProfileResponse.ts
+++ b/src/api/transformdApiSearchProfileResponse.ts
@@ -15,8 +15,8 @@ export interface ProfileSearchResponseData {
 
 export interface ProfileSearchResponseRecord {
   values: ProfileSearchResponseValues
-  groupID: number
-  lastUpdated: number
+  group_id: number
+  last_updated: number
   created: number
   id: string
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,7 @@ export async function execute(context: Context): Promise<void> {
     const webhookResponse = await webhookConnector.send(inputJson[i])
     if (webhookResponse.status === 'created') {
       console.log(
-        `Event '${webhookResponse.eventID}' created for session identifier '${searchValue}'.`
+        `Event '${webhookResponse.event_id}' created for session identifier '${searchValue}'.`
       )
     } else {
       // TODO: Check to see if status !== 'created' is an error

--- a/src/webhook/transformdDemoWebhookResponse.ts
+++ b/src/webhook/transformdDemoWebhookResponse.ts
@@ -4,7 +4,7 @@
  */
 
 export interface TransformdDemoWebhookResponse {
-  eventID: string
+  event_id: string
   status: string
   client: string
 }


### PR DESCRIPTION
This PR fixes the auto-generated key fields used in the API and webhook responses. The quicktype utiility converted the snake-case elements to camel-case.

Fixes: #21